### PR TITLE
Missing close brace for server block

### DIFF
--- a/nginx-redirect.conf
+++ b/nginx-redirect.conf
@@ -53,4 +53,5 @@ http {
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
+  }
 }


### PR DESCRIPTION
There's a missing } in nginx-redirect.conf